### PR TITLE
Add property mapping for Fahrplan import

### DIFF
--- a/src/Application/Model/Ticket.php
+++ b/src/Application/Model/Ticket.php
@@ -107,6 +107,7 @@
 			'track' => 'Fahrplan.Track',
 			'language' => 'Fahrplan.Language',
 			'abstract' => 'Fahrplan.Abstract',
+			'url' => 'Fahrplan.URL',
 			// inofficial properties
 			'video_download_url' => 'Fahrplan.VideoDownloadURL'
 		];


### PR DESCRIPTION
This adds the url field of events in frab schedule exports to imported tickets. See issue #152.