### PR TITLE
Add authentication options for import

### DIFF
--- a/src/Application/Controller/Import.php
+++ b/src/Application/Controller/Import.php
@@ -452,14 +452,14 @@
 				switch ($import['auth_type']) {
 					case 'basic':
 						$client->setAuthentication(
-							$import['auth_user'],
-							$import['auth_password']
+							(isset($import['auth_user']))? $import['auth_user'] : '',
+							(isset($import['auth_password']))? $import['auth_password'] : ''
 						);
 						break;
 					case 'header':
 						$client->addHeader(
 							'Authentication',
-							$import['auth_header']
+							(isset($import['auth_header']))? $import['auth_header'] : ''
 						);
 						break;
 				}

--- a/src/Application/Migrations/05_import.sql
+++ b/src/Application/Migrations/05_import.sql
@@ -1,9 +1,17 @@
+CREATE TYPE enum_import_auth_type AS ENUM (
+	'basic',
+	'header');
+
 CREATE TABLE tbl_import
 (
   id bigserial NOT NULL,
   project_id bigint NOT NULL,
   user_id bigint NOT NULL,
   url text NOT NULL,
+  auth_type enum_import_auth_type,
+  auth_user character varying(256),
+  auth_password character varying(256),
+  auth_header text,
   xml xml NOT NULL,
   version character varying(128) NOT NULL,
   rooms json,

--- a/src/Application/Migrations/__2018-06-01_import_auth.sql
+++ b/src/Application/Migrations/__2018-06-01_import_auth.sql
@@ -1,0 +1,8 @@
+CREATE TYPE enum_import_auth_type AS ENUM (
+	'basic',
+	'header');
+
+ALTER TABLE tbl_import ADD COLUMN auth_type enum_import_auth_type;
+ALTER TABLE tbl_import ADD COLUMN auth_user character varying(256);
+ALTER TABLE tbl_import ADD COLUMN auth_password character varying(256);
+ALTER TABLE tbl_import ADD COLUMN auth_header text;

--- a/src/Application/View/import/index.html.php
+++ b/src/Application/View/import/index.html.php
@@ -28,6 +28,22 @@
 			<li>
 				<?= $f->input('url','XML URL', '', ['class' => 'wide', 'disabled' => $project['read_only']]); ?>
 			</li>
+			<li>
+				<?= $f->select(
+					'auth_type',
+					'Authentication',
+					[
+						'' => 'No Authentication',
+						'basic' => 'Basic HTTP Authentication',
+						'header' => 'Authentication Header'
+					],
+					'',
+					['data-import-auth-type-value']
+				); ?>
+			</li>
+			<li><?= $f->input('auth_user', 'Username', '', ['data-import-auth-type' => 'basic']); ?></li>
+			<li><?= $f->password('auth_password', 'Password', ['data-import-auth-type' => 'basic']); ?></li>
+			<li><?= $f->input('auth_header', 'Authentication Header', '', ['class' => 'wide', 'data-import-auth-type' => 'header']); ?></li>
 			<li><?= $f->submit('Create new import', ['disabled' => $project['read_only']]); ?></li>
 		</ul>
 	</fieldset>

--- a/src/Public/javascript/main.js
+++ b/src/Public/javascript/main.js
@@ -1978,4 +1978,11 @@ $(function() {
       event.preventDefault();
     }
   });
+  
+  $('[data-import-auth-type-value]')
+    .change(function(event) {
+      $('[data-import-auth-type]').hide();
+      $('[data-import-auth-type="' + event.target.value + '"]').show();
+    })
+    .change();
 });


### PR DESCRIPTION
This adds options for HTTP basic auth and a user definable `Authentication` header for import.

Authentication options are currently reused when repeating an import, but are not changeable or viewable.