### PR TITLE
ids now have 5 digits, extend width

### DIFF
--- a/src/Public/css/main.css
+++ b/src/Public/css/main.css
@@ -1401,7 +1401,7 @@ ul.tickets li a.link:hover, ul.tickets li a.link:focus {
 }
 
 ul.tickets li.child a.link {
-  left: 3.7em;
+  left: 4.5em;
 }
 
 ul.tickets li span {
@@ -1424,7 +1424,7 @@ ul.tickets li span.vid, ul.tickets li span.title {
 }
 
 ul.tickets li span.vid {
-	width: 2.4em;
+	width: 3em;
 	margin-left: 6px;
 	padding-right: 5px;
 	border-right: 1px solid #e4e4e4;

--- a/src/Public/css/main.css
+++ b/src/Public/css/main.css
@@ -869,8 +869,8 @@ h2.ticket span.title {
 
 h2.ticket span.fahrplan {
   display: block;
-	width: 2.3em;
-	border-right: 1px solid #e0e0e0;
+  width: 3em;
+  border-right: 1px solid #e0e0e0;
   background-color: #fff;
   line-height: 120%;
   margin-right: 0.2em;


### PR DESCRIPTION
Some conferences e.g. 35C3 now arrived at 5 digit ids... Already deployed on tracker.c3voc.de