### PR TITLE
Web: order encoding profile versions dropdown in project settings

### DIFF
--- a/src/Application/View/projects/settings/profiles.html.php
+++ b/src/Application/View/projects/settings/profiles.html.php
@@ -29,7 +29,7 @@
 					<?= $f->select(
 						'versions[' . $index . '][1]',
 						null,
-						$version->EncodingProfile->Versions->indexBy('id', 'encodingProfileVersionTitle')->toArray(),
+						$version->EncodingProfile->Versions->indexBy('id', 'encodingProfileVersionTitle')->orderBy('revision')->toArray(),
 						$version['id'],
 						['data-encoding-profile-version-id' => $version['id'], 'data-encoding-profile-index' => $index],
 						false


### PR DESCRIPTION
Encoding profile versions may appear unordered in the dropdown, which leads to errors if a project administrator wants to make sure that the most current revision of an encoding profile version is selected.