### PR TITLE
Fix: feed page includes failed tickets for cutting

### DIFF
--- a/src/Application/Controller/Tickets.php
+++ b/src/Application/Controller/Tickets.php
@@ -424,8 +424,8 @@
 			}
 						
 			$this->stats = [
-				'cutting' => Ticket::countByNextState($this->project['id'], 'recording', 'cutting'),
-				'checking' => Ticket::countByNextState($this->project['id'], 'encoding', 'checking'),
+				'cutting' => Ticket::countNonfailedByNextState($this->project['id'], 'recording', 'cutting'),
+				'checking' => Ticket::countNonfailedByNextState($this->project['id'], 'encoding', 'checking'),
 				'fixing' => Ticket::findAll()->where(['failed' => true, 'project_id' => $this->project['id']])->count()
 			];
 			$this->progress = Ticket::getTotalProgress($this->project['id']);

--- a/src/Application/Model/Ticket.php
+++ b/src/Application/Model/Ticket.php
@@ -648,16 +648,14 @@
 		/*
 			Statistics
 		*/
-		public static function countByNextState($project, $ticketType, $ticketState) {
+		public static function countNonfailedByNextState($project, $ticketType, $ticketState) {
 			return Ticket::findAll()
 				->where([
 					'ticket_type' => $ticketType,
-					'project_id' => $project
+					'project_id' => $project,
+					'ticket_state_next' => $ticketState,
+					'failed' => false,
 				])
-				->where(
-					'ticket_state_next = ?',
-					[$ticketState]
-				)
 				->count();
 		}
 		


### PR DESCRIPTION
The numbers on the feed page are misleading, because failed tickets in prepared state count for "cutting" as well as "failed".