### PR TITLE
Bugfix for SQL function

### DIFF
--- a/src/Application/Migrations/18_function_ticket_dependency_missing.sql
+++ b/src/Application/Migrations/18_function_ticket_dependency_missing.sql
@@ -6,7 +6,7 @@ SET ROLE TO postgres;
 -- returns true if:
 --   - given ID is an encoding ticket
 --   - given ID's profile does have a dependency
---   - that dependency is not met in the given ID's project
+--   - no encoding ticket among the given ID's sibling tickets has that dependee profile
 -- In all other cases, including the cases where this check does not
 -- make any sense, it will return false.
 
@@ -37,7 +37,7 @@ BEGIN
 	WHERE
 		depender.id = param_depender_ticket_id;
 
-	RETURN result;
+	RETURN COALESCE(result, false);
 
 END
 $$

--- a/src/Application/Migrations/18_function_ticket_dependency_missing.sql
+++ b/src/Application/Migrations/18_function_ticket_dependency_missing.sql
@@ -32,7 +32,7 @@ BEGIN
 		tbl_encoding_profile ep2 ON ep2.id = ep.depends_on
 	LEFT JOIN
 		tbl_encoding_profile_version epv2 ON epv2.encoding_profile_id = ep2.id
-	LEFT JOIN
+	INNER JOIN
 		tbl_ticket dependee ON dependee.encoding_profile_version_id = epv2.id AND dependee.parent_id = depender.parent_id
 	WHERE
 		depender.id = param_depender_ticket_id;

--- a/src/Application/Migrations/__2019-01-03_fix-dependee-ticket-missing.sql
+++ b/src/Application/Migrations/__2019-01-03_fix-dependee-ticket-missing.sql
@@ -1,0 +1,38 @@
+﻿BEGIN;
+
+SET ROLE TO postgres;
+
+CREATE OR REPLACE FUNCTION ticket_dependee_missing(param_depender_ticket_id bigint)
+  RETURNS boolean AS
+  $$
+DECLARE
+	result boolean;
+BEGIN
+
+	SELECT
+		epv.id IS NOT NULL -- check this is actually an encoding ticket
+		AND ep.depends_on IS NOT NULL -- check that this is a ticket of a depending profile
+		AND dependee.id IS NULL -- this is the error condition to return true on
+		INTO result
+	FROM
+		tbl_ticket depender
+	LEFT JOIN
+		tbl_encoding_profile_version epv ON epv.id = depender.encoding_profile_version_id
+	LEFT JOIN
+		tbl_encoding_profile ep ON epv.encoding_profile_id = ep.id
+	LEFT JOIN
+		tbl_encoding_profile ep2 ON ep2.id = ep.depends_on
+	LEFT JOIN
+		tbl_encoding_profile_version epv2 ON epv2.encoding_profile_id = ep2.id
+	LEFT JOIN
+		tbl_ticket dependee ON dependee.encoding_profile_version_id = epv2.id AND dependee.parent_id = depender.parent_id
+	WHERE
+		depender.id = param_depender_ticket_id;
+
+	RETURN COALESCE(result, false);
+
+END
+$$
+LANGUAGE plpgsql;
+
+COMMIT;

--- a/src/Application/Migrations/__2019-05-24_fix-dependee-ticket-missing.sql
+++ b/src/Application/Migrations/__2019-05-24_fix-dependee-ticket-missing.sql
@@ -24,7 +24,7 @@ BEGIN
 		tbl_encoding_profile ep2 ON ep2.id = ep.depends_on
 	LEFT JOIN
 		tbl_encoding_profile_version epv2 ON epv2.encoding_profile_id = ep2.id
-	LEFT JOIN
+	INNER JOIN
 		tbl_ticket dependee ON dependee.encoding_profile_version_id = epv2.id AND dependee.parent_id = depender.parent_id
 	WHERE
 		depender.id = param_depender_ticket_id;


### PR DESCRIPTION
There was a wrong join in the function definition, which causes wrong behaviour as soon as there are multiple encoding profile versions for the depending and dependee profiles.

Changes the join clause in the installation script and supersedes the database migration script from January 2019.