### PR TITLE
Allow state skipping for dependent encoding profiles

### DIFF
--- a/src/Application/Controller/XMLRPC/Handler.php
+++ b/src/Application/Controller/XMLRPC/Handler.php
@@ -485,7 +485,7 @@
 				throw new Exception(__FUNCTION__.': ticket is not in initial state!',1304);
 			}
 			
-			$commenceState = ProjectTicketState::getCommenceState($ticket['project_id'], $ticket['ticket_type']);
+			$commenceState = ProjectTicketState::getCommenceState($ticket_id);
 			if(!$commenceState) {
 				throw new Exception(__FUNCTION__.': ticket has no commence state!',1305);
 			}

--- a/src/Application/Migrations/04_projects.sql
+++ b/src/Application/Migrations/04_projects.sql
@@ -50,6 +50,7 @@ CREATE TABLE tbl_project_ticket_state
   ticket_type enum_ticket_type NOT NULL,
   ticket_state enum_ticket_state NOT NULL,
   service_executable boolean NOT NULL DEFAULT false,
+  skip_on_dependent boolean NOT NULL DEFAULT false,
   CONSTRAINT tbl_project_ticket_state_pk PRIMARY KEY (project_id, ticket_type, ticket_state),
   CONSTRAINT tbl_project_ticket_state_project_fk FOREIGN KEY (project_id)
       REFERENCES tbl_project (id) MATCH SIMPLE

--- a/src/Application/Migrations/06_tickets.sql
+++ b/src/Application/Migrations/06_tickets.sql
@@ -40,7 +40,7 @@ $BODY$
   DECLARE
    next_state record;
   BEGIN
-    next_state := ticket_state_next(NEW.project_id, NEW.ticket_type, NEW.ticket_state);
+    next_state := ticket_state_next(NEW.id, NEW.ticket_state);
 
     NEW.ticket_state_next := next_state.ticket_state;
     NEW.service_executable := next_state.service_executable;
@@ -95,7 +95,7 @@ $BODY$
       (progress, ticket_state_next, service_executable)
         = (tp, (n).ticket_state, (n).service_executable)
     FROM (
-      SELECT id, ticket_state_next(t2.project_id, t2.ticket_type, t2.ticket_state) AS n, ticket_progress(t2.id) as tp
+      SELECT id, ticket_state_next(t2.id) AS n, ticket_progress(t2.id) as tp
       FROM tbl_ticket t2
       WHERE t2.project_id = param_project_id AND param_project_id IS NOT NULL
     ) AS x

--- a/src/Application/Migrations/__2019-09-29_skip_dependent.sql
+++ b/src/Application/Migrations/__2019-09-29_skip_dependent.sql
@@ -1,0 +1,184 @@
+BEGIN;
+	
+SET ROLE TO postgres;
+
+ALTER TABLE tbl_project_ticket_state
+  ADD COLUMN skip_on_dependent boolean NOT NULL DEFAULT false;
+
+ALTER TABLE tbl_ticket_state
+  ADD COLUMN skippable_on_dependent boolean NOT NULL DEFAULT false;
+
+
+UPDATE tbl_ticket_state
+SET skippable_on_dependent = true
+WHERE ticket_type = 'encoding'
+  AND ticket_state IN ('checking', 'checked', 'postprocessing', 'postprocessed', 'ready to release');
+
+DROP FUNCTION IF EXISTS ticket_state_next(bigint);
+DROP FUNCTION IF EXISTS ticket_state_next(bigint, enum_ticket_type);
+DROP FUNCTION IF EXISTS ticket_state_next(bigint, enum_ticket_type, enum_ticket_state);
+
+DROP FUNCTION IF EXISTS ticket_state_previous(bigint);
+DROP FUNCTION IF EXISTS ticket_state_previous(bigint, enum_ticket_type);
+DROP FUNCTION IF EXISTS ticket_state_previous(bigint, enum_ticket_type, enum_ticket_state);
+
+DROP FUNCTION IF EXISTS ticket_state_commence(bigint, enum_ticket_type);
+DROP FUNCTION IF EXISTS ticket_state_commence(bigint);
+
+
+CREATE OR REPLACE FUNCTION update_ticket_next_state()
+  RETURNS trigger AS
+$BODY$
+  DECLARE
+   next_state record;
+  BEGIN
+    next_state := ticket_state_next(NEW.id, NEW.ticket_state);
+
+    NEW.ticket_state_next := next_state.ticket_state;
+    NEW.service_executable := next_state.service_executable;
+
+    RETURN NEW;
+  END
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+
+
+CREATE OR REPLACE FUNCTION update_all_tickets_progress_and_next_state(param_project_id bigint)
+  RETURNS VOID AS
+$BODY$
+  BEGIN
+
+    UPDATE tbl_ticket t SET
+      (progress, ticket_state_next, service_executable)
+        = (tp, (n).ticket_state, (n).service_executable)
+    FROM (
+      SELECT id, ticket_state_next(t2.id) AS n, ticket_progress(t2.id) as tp
+      FROM tbl_ticket t2
+      WHERE t2.project_id = param_project_id AND param_project_id IS NOT NULL
+    ) AS x
+    WHERE t.id = x.id;
+
+  END;
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+
+
+CREATE OR REPLACE FUNCTION ticket_state_next(param_ticket_id bigint, param_ticket_state enum_ticket_state DEFAULT NULL)
+  RETURNS TABLE(ticket_state enum_ticket_state, service_executable boolean) AS
+  $$
+DECLARE
+BEGIN
+	RETURN QUERY
+	SELECT
+		pts.ticket_state, pts.service_executable
+	FROM
+		tbl_ticket t
+	JOIN
+		tbl_ticket_state ts_this ON ts_this.ticket_type = t.ticket_type AND ts_this.ticket_state = COALESCE(param_ticket_state, t.ticket_state)
+	JOIN
+		tbl_project_ticket_state pts ON pts.project_id = t.project_id AND pts.ticket_type = t.ticket_type
+	JOIN
+		tbl_ticket_state ts_other ON ts_other.ticket_type = pts.ticket_type AND ts_other.ticket_state = pts.ticket_state
+	WHERE
+		t.id = param_ticket_id AND
+		ts_other.sort > ts_this.sort AND
+		(pts.skip_on_dependent = FALSE OR
+		( /* is master encoding ticket */
+			SELECT ep.depends_on
+			FROM tbl_ticket t
+			INNER JOIN tbl_encoding_profile_version epv ON epv.id = t.encoding_profile_version_id
+			INNER JOIN tbl_encoding_profile ep ON ep.id = epv.encoding_profile_id
+			WHERE t.id = param_ticket_id
+		) IS NULL )
+	ORDER BY ts_other.sort ASC
+	LIMIT 1;
+
+	IF NOT FOUND THEN
+		RETURN QUERY SELECT NULL::enum_ticket_state, false;
+	END IF;
+END
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ticket_state_previous(param_ticket_id bigint, param_ticket_state enum_ticket_state DEFAULT NULL)
+  RETURNS TABLE(ticket_state enum_ticket_state, service_executable boolean) AS
+  $$
+DECLARE
+BEGIN
+	RETURN QUERY
+	SELECT
+		pts.ticket_state, pts.service_executable
+	FROM
+		tbl_ticket t
+	JOIN
+		tbl_ticket_state ts_this ON ts_this.ticket_type = t.ticket_type AND ts_this.ticket_state = COALESCE(param_ticket_state, t.ticket_state)
+	JOIN
+		tbl_project_ticket_state pts ON pts.project_id = t.project_id AND pts.ticket_type = t.ticket_type
+	JOIN
+		tbl_ticket_state ts_other ON ts_other.ticket_type = pts.ticket_type AND ts_other.ticket_state = pts.ticket_state
+	WHERE
+		t.id = param_ticket_id AND
+		ts_other.sort < ts_this.sort AND
+		(pts.skip_on_dependent = FALSE OR
+		( /* is master encoding ticket */
+			SELECT ep.depends_on
+			FROM tbl_ticket t
+			JOIN tbl_encoding_profile_version epv ON epv.id = t.encoding_profile_version_id
+			JOIN tbl_encoding_profile ep ON ep.id = epv.encoding_profile_id
+			WHERE t.id = param_ticket_id
+		) IS NULL )
+	ORDER BY ts_other.sort DESC
+	LIMIT 1;
+
+	IF NOT FOUND THEN
+		RETURN QUERY SELECT NULL::enum_ticket_state, false;
+	END IF;
+END
+$$
+LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION ticket_state_commence(param_ticket_id bigint)
+  RETURNS enum_ticket_state AS
+$$
+DECLARE
+  var_project_id bigint;
+  var_ticket_type enum_ticket_type;
+  ret enum_ticket_state;
+  next_state record;
+BEGIN
+  SELECT
+    project_id, ticket_type INTO var_project_id, var_ticket_type
+  FROM
+    tbl_ticket t
+  WHERE
+    t.id = param_ticket_id;
+
+  -- special case: meta ticket, since it has no serviceable states
+  IF var_ticket_type = 'meta' THEN
+    RETURN 'staged'::enum_ticket_state;
+  END IF;
+
+  ret := (SELECT ticket_state_initial(var_project_id, var_ticket_type));
+
+  WHILE ret IS NOT NULL LOOP
+    SELECT * INTO next_state FROM ticket_state_next(param_ticket_id, ret);
+    IF NOT FOUND THEN
+      ret := NULL;
+      EXIT;
+    END IF;
+
+    -- exit, if serviceable state is found
+    EXIT WHEN next_state.service_executable IS TRUE;
+
+    -- otherwise set current state as possible commence state
+    ret := next_state.ticket_state;
+  END LOOP;
+
+  RETURN ret;
+END
+$$
+LANGUAGE plpgsql;
+
+
+COMMIT;

--- a/src/Application/Model/ProjectTicketState.php
+++ b/src/Application/Model/ProjectTicketState.php
@@ -20,31 +20,10 @@
 			]
 		];
 		
-		// TODO: use Ticket::queryNextState / queryPreviousState?
-		public static function getNextState($project, $type, $state) {
+		public static function getCommenceState($ticket) {
 			$handle = Database::$Instance->query(
-				'SELECT * FROM ticket_state_next(?, ?, ?)',
-				[$project, $type, $state]
-			);
-			$row = $handle->fetch();
-			
-			return ($row === false)? null : $row;
-		}
-		
-		public static function getPreviousState($project, $type, $state) {
-			$handle = Database::$Instance->query(
-				'SELECT * FROM ticket_state_previous(?, ?, ?)',
-				[$project, $type, $state]
-			);
-			
-			$row = $handle->fetch();
-			return ($row === false)? null : $row;
-		}
-		
-		public static function getCommenceState($project, $type) {
-			$handle = Database::$Instance->query(
-				'SELECT ticket_state_commence(?, ?)',
-				[$project, $type]
+				'SELECT ticket_state_commence(?)',
+				[$ticket]
 			);
 			
 			return $handle->fetch()['ticket_state_commence'];

--- a/src/Application/Model/Ticket.php
+++ b/src/Application/Model/Ticket.php
@@ -904,13 +904,9 @@
 			return (new Database_Query(''))
 				->select('ticket_state')
 				->from(
-					'ticket_state_previous(?, ?, ?)',
+					'ticket_state_previous(?)',
 					'previous_state',
-					[
-						$this['project_id'],
-						$this['ticket_type'],
-						($state === null)? $this['ticket_state'] : $state
-					]
+					[$this['id']]
 				);
 		}
 		
@@ -918,16 +914,12 @@
 			return (new Database_Query(''))
 				->select('ticket_state')
 				->from(
-					'ticket_state_next(?, ?, ?)',
+					'ticket_state_next(?)',
 					'next_state',
-					[
-						$this['project_id'],
-						$this['ticket_type'],
-						($state === null)? $this['ticket_state'] : $state
-					]
+					[$this['id']]
 				);
 		}
-		
+
 		public function findNextForAction($state) {
 			$next = null;
 			

--- a/src/Application/Model/TicketState.php
+++ b/src/Application/Model/TicketState.php
@@ -9,7 +9,9 @@
 		public $hasOne = [
 			'ProjectTicketState' => [
 				'foreign_key' => ['ticket_type', 'ticket_state'],
-				'select' => '(ticket_state IS NOT NULL) AS project_enabled, service_executable AS project_service_executable'
+				'select' => '(ticket_state IS NOT NULL) AS project_enabled,' .
+					'service_executable AS project_service_executable,' .
+					'skip_on_dependent AS project_skip_on_dependent'
 			]
 		];
 		

--- a/src/Application/View/projects/settings/states.html.php
+++ b/src/Application/View/projects/settings/states.html.php
@@ -2,7 +2,7 @@
 <?= $this->render('projects/settings/_header'); ?>
 
 <?php $type = null;
-$typeRows = 0; ?>
+$first = false; ?>
 
 <?= $f = $stateForm(['disabled' => $project['read_only']]); ?>
 	<div class="project-settings-save">
@@ -17,54 +17,74 @@ $typeRows = 0; ?>
 				$encodingStates, (!empty($project))? $project['dependee_ticket_trigger_state'] : null) ?>
 		</fieldset>
 	</div>
-		<?php foreach ($states as $index => $state): ?>
-			<?php if ($type != $state['ticket_type']):
-				$type = $state['ticket_type'];
-				
-				if ($typeRows > 1):
-					$typeRows = 0; ?>
-							</tbody>
-						</table>
-					</div>
-				<?php endif;
-				if ($typeRows == 0): ?>
-					<div class="column-50">
-						<table class="default">
-							<thead>
-								<tr>
-									<th width="20%">Type</th>
-									<th width="40%">State</th>
-									<th width="5%">Service</th>
-								</tr>
-							</thead>
-							<tbody>
-				<?php endif;
-				$typeRows++; ?>
+	<div class="column-50">
+		<table class="default">
+			<thead>
 				<tr>
-					<td><?= h(mb_ucfirst($type)); ?></td>
-			<?php else: ?>
+					<th width="20%">Type</th>
+					<th width="40%">State</th>
+					<th width="5%">Service</th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($states as $index => $state) {
+					if ($state['ticket_type'] === 'encoding') {
+						continue;
+					}
+					
+					if ($type !== $state['ticket_type']) {
+						$type = $state['ticket_type'];
+						$first = true;
+					} else {
+						$first = false;
+					}
+					
+					
+					echo $this->render('projects/settings/states/_state', [
+						'f' => $f,
+						'first' => $first,
+						'index' => $index,
+						'state' => $state
+					]);
+				} ?>
+			</tbody>
+		</table>
+	</div>
+	<div class="column-50">
+		<table class="default">
+			<thead>
 				<tr>
-					<td class="empty"></td>
-			<?php endif; ?>
-				<td><?=
-					$f->checkbox(
-						'States[' . $index . '][ticket_state]',
-						$state['ticket_state'],
-						$state['project_enabled'],
-						['value' => $state['ticket_state']] +
-							(($state['project_enabled'])?
-								['data-association-destroy' => 'States[' . $index . '][_destroy]'] :
-								[]),
-						false
-					) .
-					$f->hidden('States[' . $index . '][ticket_type]', $state['ticket_type']);
-				?></td>
-				<td class="right"><?php if ($state['service_executable']) {
-					echo $f->checkbox('States[' . $index . '][service_executable]', null, $state['project_service_executable'], [], false);
-				} ?></td>
-			</tr>
-			<?php $f->register('States[' . $index . '][_destroy]'); ?>
-		<?php endforeach; ?>
+					<th width="20%">Type</th>
+					<th width="35%">State</th>
+					<th width="5%">Service</th>
+					<th width="5%">
+						<span aria-label="Select if the state will be skipped
+in dependent encoding profiles" data-tooltip="true">Skip</span>
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($states as $index => $state) {
+					if ($state['ticket_type'] !== 'encoding') {
+						continue;
+					}
+					
+					if ($type !== $state['ticket_type']) {
+						$type = $state['ticket_type'];
+						$first = true;
+					} else {
+						$first = false;
+					}
+					
+					
+					echo $this->render('projects/settings/states/_state', [
+						'f' => $f,
+						'first' => $first,
+						'index' => $index,
+						'state' => $state,
+						'skip' => true
+					]);
+				} ?>
 			</tbody>
 		</table>
 	</div>

--- a/src/Application/View/projects/settings/states/_state.html.php
+++ b/src/Application/View/projects/settings/states/_state.html.php
@@ -1,0 +1,30 @@
+<?php if ($first): ?>
+	<tr>
+		<td><?= h(mb_ucfirst($state['ticket_type'])); ?></td>
+<?php else: ?>
+	<tr>
+		<td class="empty"></td>
+<?php endif; ?>
+	<td><?=
+		$f->checkbox(
+			'States[' . $index . '][ticket_state]',
+			$state['ticket_state'],
+			$state['project_enabled'],
+			['value' => $state['ticket_state']] +
+				(($state['project_enabled'])?
+					['data-association-destroy' => 'States[' . $index . '][_destroy]'] :
+					[]),
+			false
+		) .
+		$f->hidden('States[' . $index . '][ticket_type]', $state['ticket_type']);
+	?></td>
+	<td class="right"><?php if ($state['service_executable']) {
+		echo $f->checkbox('States[' . $index . '][service_executable]', null, $state['project_service_executable'], [], false);
+	} ?></td>
+	<?php if (!empty($skip)): ?>
+		<td class="right"><?php if ($state['skippable_on_dependent']) {
+			echo $f->checkbox('States[' . $index . '][skip_on_dependent]', null, $state['project_skip_on_dependent'], ['title' => 'This state will be skipped in dependent encoding profiles'], false);
+		} ?></td>
+	<?php endif; ?>
+</tr>
+<?php $f->register('States[' . $index . '][_destroy]'); ?>


### PR DESCRIPTION
Implements #160, supersedes #171.

We may additionally want to check if the ticket is currently in a skippable state and do not skip states in this case. This would happen if the user manually set the ticket to a skippable state (e.g. ticket is currently in checking).

@pegro Requested changes from #171 should be implemented, can you have a look?