### PR TITLE
disable logging for progress updates

### DIFF
--- a/src/Application/Controller/XMLRPC/Handler.php
+++ b/src/Application/Controller/XMLRPC/Handler.php
@@ -610,9 +610,9 @@
 					continue;
 				} elseif($value !== '') {
 					$ticket_properties[] = ['name' => $name, 'value' => $value];
-                    if(strpos($name, "Progress." ) === false ){
-                        $log_message[] = $name . '=' . $value;
-                    }
+					if(strpos($name, "Progress." ) === false ){
+						$log_message[] = $name . '=' . $value;
+					}
 				} else {
 					$ticket_properties[] = ['name' => $name, '_destroy' => 1];
 					$log_message[] = 'deleting property: ' . $name;

--- a/src/Application/Controller/XMLRPC/Handler.php
+++ b/src/Application/Controller/XMLRPC/Handler.php
@@ -610,13 +610,15 @@
 					continue;
 				} elseif($value !== '') {
 					$ticket_properties[] = ['name' => $name, 'value' => $value];
-					$log_message[] = $name . '=' . $value;
+                    if(strpos($name, "Progress." ) === false ){
+                        $log_message[] = $name . '=' . $value;
+                    }
 				} else {
 					$ticket_properties[] = ['name' => $name, '_destroy' => 1];
 					$log_message[] = 'deleting property: ' . $name;
 				}
 			}
-			if($ticket->save(['properties' => $ticket_properties])) {
+			if($ticket->save(['properties' => $ticket_properties]) && count($log_message) > 1) {
 				LogEntry::create([
 					'ticket_id' => $ticket['id'],
 					'handle_id' => $this->worker['id'],


### PR DESCRIPTION
ffmpeg has an option `-progress` where you can put an url an ffmpeg pushes approximately every second an update. I've build a little programm which sends some of these values to the tracker. But  because of the short-lived nature of the values it would be unnecessary more stress on the database if there would be log entries created for those progress updates.