### PR TITLE
rpc-api: also create missing recording tickets

### DIFF
--- a/src/Application/Controller/XMLRPC/Handler.php
+++ b/src/Application/Controller/XMLRPC/Handler.php
@@ -341,6 +341,10 @@
 					'comment' => 'ticket created'
 				]);
 				
+				Ticket::createMissingRecordingTickets(
+					$project['id']
+				);
+				
 				Ticket::createMissingEncodingTickets(
 					$project['id']
 				);


### PR DESCRIPTION
Tickets created by the XMLRPC api are currently missing recording tickets.