### PR TITLE
Improve compatibility with PHP 8

### DIFF
--- a/src/Config/Config.Default.php
+++ b/src/Config/Config.Default.php
@@ -21,6 +21,8 @@
 	
 	session_set_cookie_params(0, '/', null, false, true);
 	
-	libxml_disable_entity_loader(true);
+	if (PHP_MAJOR_VERSION < 8) {
+		libxml_disable_entity_loader(true);
+	}
 	
 ?>


### PR DESCRIPTION
Fix issues with static variables inside classes.

libxml_disable_entity_loader is deprecated in PHP 8.